### PR TITLE
[YAPPIOS-65] 요일별 루틴 순서 편집 API 구현

### DIFF
--- a/src/main/java/com/yapp/project/routine/controller/RoutineController.java
+++ b/src/main/java/com/yapp/project/routine/controller/RoutineController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -49,5 +50,13 @@ public class RoutineController {
     @DeleteMapping("/{routineId}")
     public ResponseEntity deleteRoutine(@PathVariable Long routineId) {
         return routineService.deleteRoutine(routineId, AccountUtil.getAccount());
+    }
+
+    @PatchMapping("/sequence/{day}")
+    public List<RoutineDTO.ResponseRoutineDto> updateRoutineSequence(
+            @PathVariable Week day, @RequestBody ArrayList<Long> sequence) {
+//        System.out.println("day: " + day + ", sequence: " + sequence);
+
+        return routineService.updateRoutineSequence(day, sequence, AccountUtil.getAccount());
     }
 }

--- a/src/main/java/com/yapp/project/routine/controller/RoutineController.java
+++ b/src/main/java/com/yapp/project/routine/controller/RoutineController.java
@@ -55,8 +55,6 @@ public class RoutineController {
     @PatchMapping("/sequence/{day}")
     public List<RoutineDTO.ResponseRoutineDto> updateRoutineSequence(
             @PathVariable Week day, @RequestBody ArrayList<Long> sequence) {
-//        System.out.println("day: " + day + ", sequence: " + sequence);
-
         return routineService.updateRoutineSequence(day, sequence, AccountUtil.getAccount());
     }
 }

--- a/src/main/java/com/yapp/project/routine/domain/Routine.java
+++ b/src/main/java/com/yapp/project/routine/domain/Routine.java
@@ -50,7 +50,7 @@ public class Routine {
     private List<Retrospect> retrospects = new ArrayList<>();
 
     @Builder
-    public Routine(Account account, RoutineDTO.RequestRoutineDto newRoutine){
+    public Routine(Account account, RoutineDTO.RequestRoutineDto newRoutine, Long id){
         this.account = account;
         this.title = newRoutine.getTitle();
         this.goal = newRoutine.getGoal();
@@ -58,6 +58,7 @@ public class Routine {
         this.isDelete = false;
         this.category = newRoutine.getCategory();
         this.createdAt = LocalDateTime.now();
+        this.id = id;
     }
 
     public void addDays(List<RoutineDay> days) {

--- a/src/main/java/com/yapp/project/routine/domain/RoutineDay.java
+++ b/src/main/java/com/yapp/project/routine/domain/RoutineDay.java
@@ -39,6 +39,10 @@ public class RoutineDay {
         this.createdAt = LocalDateTime.now();
     }
 
+    public void updateSequence(Long sequence) {
+        this.sequence = sequence;
+    }
+
     public void setRoutine(Routine routine) {
         this.routine = routine;
     }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -29,7 +29,7 @@ public class RoutineService {
     }
 
     public ResponseEntity deleteRoutine(Long routineId, Account account) {
-        Routine routine = findIsExist(routineId);
+        Routine routine = findIsExistById(routineId);
         checkIsMine(account, routine);
         routineRepository.delete(routine);
         return ResponseEntity.ok().build();
@@ -37,7 +37,7 @@ public class RoutineService {
 
     public RoutineDTO.ResponseRoutineDto updateRoutine(Long routineId, RoutineDTO.RequestRoutineDto updateRoutine, Account account) {
         checkDataIsNull(updateRoutine);
-        Routine routine = findIsExist(routineId);
+        Routine routine = findIsExistById(routineId);
         checkIsMine(account, routine);
         routine.updateRoutine(updateRoutine);
         updateDayList(updateRoutine, routine);
@@ -53,7 +53,7 @@ public class RoutineService {
     }
 
     public RoutineDTO.ResponseRoutineDto getRoutine(Long routineId, Account account) {
-        Routine routine = findIsExist(routineId);
+        Routine routine = findIsExistById(routineId);
         checkIsMine(account, routine);
         return RoutineDTO.ResponseRoutineDto.builder()
                 .routine(routine).build();
@@ -87,7 +87,7 @@ public class RoutineService {
         if(!account.getId().equals(routine.getAccount().getId())) throw new BadRequestException(Content.BAD_REQUEST_GET_ROUTINE_ID, StatusEnum.BAD_REQUEST);
     }
 
-    private Routine findIsExist(Long routineId) {
+    private Routine findIsExistById(Long routineId) {
         return routineRepository.findById(routineId).orElseThrow(() -> new NotFoundRoutineException(Content.NOT_FOUND_ROUTINE, StatusEnum.NOT_FOUND));
     }
 

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -20,6 +20,14 @@ public class RoutineService {
 
     private final RoutineRepository routineRepository;
 
+    public List<RoutineDTO.ResponseRoutineDto> updateRoutineSequence(Week day, ArrayList<Long> sequence, Account account) {
+        List<Routine> routineList = findAllIsExistByID(sequence);
+        routineList.stream().forEach(x -> checkIsMine(account, x));
+        updateRoutineDaysSequence(day, sequence, routineList);
+        routineRepository.saveAll(routineList);
+        return getRoutineList(day, account);
+    }
+
     public ResponseEntity deleteRoutine(Long routineId, Account account) {
         Routine routine = findIsExist(routineId);
         checkIsMine(account, routine);
@@ -95,4 +103,18 @@ public class RoutineService {
         routine.getDays().removeAll(deleteDay);
         setDays(updateRoutine.getDays(), routine);
     }
+
+    private List<Routine> findAllIsExistByID(ArrayList<Long> sequence) {
+        return routineRepository.findAllById(sequence);
+    }
+
+    private void updateRoutineDaysSequence(Week day, ArrayList<Long> sequence, List<Routine> routineList) {
+        routineList.stream().forEach(x -> {
+            x.getDays().stream().forEach(y -> {
+                if(y.getDay().equals(day)) {
+                    y.updateSequence((long)(sequence.indexOf(x.getId()) + 1));
+                }});
+        });
+    }
+
 }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -109,23 +110,16 @@ public class RoutineService {
     }
 
     private void updateRoutineDaysSequence(Week day, ArrayList<Long> sequence, List<Routine> routineList) {
-        Long indexSequence = 1L;
-        for(Integer x: getRoutineIndex(sequence, routineList)) {
-            for(RoutineDay y: routineList.get(x).getDays())
-                if(y.getDay().equals(day)) y.updateSequence(indexSequence++);
+        HashMap<Long, Long> routineListSequence = new HashMap<>();
+        Long routineSequence = 1L;
+        for (Long seq : sequence) {
+            routineListSequence.put(seq, routineSequence++);
         }
-    }
-
-    private List<Integer> getRoutineIndex(ArrayList<Long> sequence, List<Routine> routineList) {
-        List<Integer> routineIndex = new ArrayList<>();
-        Integer seq = 0;
-        for (Long x : sequence) {
-            for (Routine y : routineList) {
-                if (y.getId().equals(x)) routineIndex.add(seq);
-                seq++;
-            }
-            seq = 0;
-        }
-        return routineIndex;
+        routineList.forEach(x -> {
+            x.getDays().forEach(y -> {
+                if(y.getDay().equals(day))
+                    y.updateSequence(routineListSequence.get(x.getId()));
+            });
+        });
     }
 }

--- a/src/main/java/com/yapp/project/routine/service/RoutineService.java
+++ b/src/main/java/com/yapp/project/routine/service/RoutineService.java
@@ -21,7 +21,7 @@ public class RoutineService {
     private final RoutineRepository routineRepository;
 
     public List<RoutineDTO.ResponseRoutineDto> updateRoutineSequence(Week day, ArrayList<Long> sequence, Account account) {
-        List<Routine> routineList = findAllIsExistByID(sequence);
+        List<Routine> routineList = findAllIsExistById(sequence);
         routineList.stream().forEach(x -> checkIsMine(account, x));
         updateRoutineDaysSequence(day, sequence, routineList);
         routineRepository.saveAll(routineList);
@@ -104,17 +104,28 @@ public class RoutineService {
         setDays(updateRoutine.getDays(), routine);
     }
 
-    private List<Routine> findAllIsExistByID(ArrayList<Long> sequence) {
+    private List<Routine> findAllIsExistById(ArrayList<Long> sequence) {
         return routineRepository.findAllById(sequence);
     }
 
     private void updateRoutineDaysSequence(Week day, ArrayList<Long> sequence, List<Routine> routineList) {
-        routineList.stream().forEach(x -> {
-            x.getDays().stream().forEach(y -> {
-                if(y.getDay().equals(day)) {
-                    y.updateSequence((long)(sequence.indexOf(x.getId()) + 1));
-                }});
-        });
+        Long indexSequence = 1L;
+        for(Integer x: getRoutineIndex(sequence, routineList)) {
+            for(RoutineDay y: routineList.get(x).getDays())
+                if(y.getDay().equals(day)) y.updateSequence(indexSequence++);
+        }
     }
 
+    private List<Integer> getRoutineIndex(ArrayList<Long> sequence, List<Routine> routineList) {
+        List<Integer> routineIndex = new ArrayList<>();
+        Integer seq = 0;
+        for (Long x : sequence) {
+            for (Routine y : routineList) {
+                if (y.getId().equals(x)) routineIndex.add(seq);
+                seq++;
+            }
+            seq = 0;
+        }
+        return routineIndex;
+    }
 }

--- a/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
+++ b/src/test/java/com/yapp/project/routine/RoutineServiceTest.java
@@ -163,4 +163,31 @@ public class RoutineServiceTest {
         assertThat(routine.getTitle()).isEqualTo(mockRoutine.getTitle());
     }
 
+    @Test
+    void Test_Update_Routine_Sequence_Success() {
+        //given
+        Account account = AccountTemplate.makeTestAccount();
+        List<Routine> routines = new ArrayList<>();
+        List<Week> newDays1 = new ArrayList<>();
+        List<Week> newDays2 = new ArrayList<>();
+        ArrayList<Long> sequence = new ArrayList<>();
+        sequence.add(2L); sequence.add(1L);
+        newDays1.add(Week.MON); newDays2.add(Week.MON); newDays2.add(Week.SUN);
+        RoutineDTO.RequestRoutineDto newRoutine1 = new RoutineDTO.RequestRoutineDto("타이틀", "목표", newDays1, "07:35", "생활"); // 1번
+        RoutineDTO.RequestRoutineDto newRoutine2 = new RoutineDTO.RequestRoutineDto("타이틀2", "목표2", newDays2, "07:35", "생활"); // 2번
+        routines.add(Routine.builder().account(account).newRoutine(newRoutine2).id(0L).build()); // 2번 -> 1번
+        routines.add(Routine.builder().account(account).newRoutine(newRoutine1).id(1L).build()); // 1번 -> 2번
+
+        // mocking
+        given(routineRepository.findAllById(sequence)).willReturn(routines);
+        given(routineRepository
+                .findAllByAccountAndDaysDayOrderByDaysSequence(account, Week.MON, Sort.by("days").descending())).willReturn(routines);
+
+        // when
+        List<RoutineDTO.ResponseRoutineDto> responseRoutineDtos = routineService.updateRoutineSequence(Week.MON, sequence, account);
+
+        // then
+        assertThat(responseRoutineDtos.get(0).getTitle()).isEqualTo(newRoutine2.getTitle());
+    }
+
 }


### PR DESCRIPTION
요일별 루틴 순서 편집 API 구현

- 요일별 루틴 순서 편집 기능 구현
  - RoutineDayRepository를 이용하면 O(N)연산이 가능하나, JPA 사용 목적을 잃게되어 이용하지 않음.
- 요일별 루틴 순서 편집 테스트 케이스 작성
  - 실패 경우는 기존 다른 테스트 케이스와 동일하여 미작성